### PR TITLE
Support for MQTT Username/Password and Enable/Disable Buzzer

### DIFF
--- a/CO2-Ampel_Plus/Buzzer.cpp
+++ b/CO2-Ampel_Plus/Buzzer.cpp
@@ -1,26 +1,30 @@
 #include "Arduino.h"
 #include "Config.h"
 #include "Buzzer.h"
+#include "DeviceConfig.h"
 
 void buzzer_init(){
-   pinMode(PIN_BUZZER, OUTPUT);
-   digitalWrite(PIN_BUZZER, LOW);
+    pinMode(PIN_BUZZER, OUTPUT);
+    digitalWrite(PIN_BUZZER, LOW);
 }
 
 void buzzer_test(){
-  buzzer_on();
-  delay(1000);
-  buzzer_off();  
+    analogWrite(PIN_BUZZER, 255/2); //Buzzer an
+    delay(1000);
+    analogWrite(PIN_BUZZER, 0); //Buzzer aus  
 }
 
 void buzzer_ack(){
-  buzzer_on();
-  delay(500);
-  buzzer_off();
+    analogWrite(PIN_BUZZER, 255/2); //Buzzer an
+    delay(500);
+    analogWrite(PIN_BUZZER, 0); //Buzzer aus  
 }
 
 void buzzer_on(){
-     analogWrite(PIN_BUZZER, 255/2); //Buzzer an  
+    device_config_t cfg = config_get_values();
+    if (cfg.buzzer_enabled){
+        analogWrite(PIN_BUZZER, 255/2); //Buzzer an
+    }  
 }
 
 void buzzer_off(){

--- a/CO2-Ampel_Plus/Config.h
+++ b/CO2-Ampel_Plus/Config.h
@@ -61,7 +61,8 @@
 #define MQTT_BROKER_ADDR "127.0.0.1"
 #define MQTT_TOPIC "sensors"
 #define MQTT_LWT_SUBTOPIC "LWT" 
-
+#define MQTT_USERNAME "username"
+#define MQTT_PASSWORD "password"
 #define MQTT_SENSOR_CO2 888
 #define MQTT_SENSOR_TEMP 889
 #define MQTT_SENSOR_HUM 890
@@ -69,6 +70,8 @@
 
 #define NUMBER_OF_WS2812_LEDS 4
 
+#define LIGHT_ENABLED true
+#define BUZZER_ENABLED true
 
 //--- Ampelhelligkeit (LEDs) ---
 #define HELLIGKEIT         180 //1-255 

--- a/CO2-Ampel_Plus/DeviceConfig.cpp
+++ b/CO2-Ampel_Plus/DeviceConfig.cpp
@@ -14,7 +14,7 @@ bool config_is_initialized(){
 }
 
 void config_set_factory_defaults(){
-  device_config_t _default_config = {1, "", "", WIFI_AP_PASSWORD, MQTT_BROKER_PORT, MQTT_BROKER_ADDR, MQTT_TOPIC, DEVICE_NAME, TEMPERATURE_OFFSET};
+  device_config_t _default_config = {1, "", "", WIFI_AP_PASSWORD, MQTT_BROKER_PORT, MQTT_BROKER_ADDR, MQTT_TOPIC, DEVICE_NAME, TEMPERATURE_OFFSET, MQTT_USERNAME, MQTT_PASSWORD, LIGHT_ENABLED, BUZZER_ENABLED};
   config_store.write(_default_config); 
 }
 

--- a/CO2-Ampel_Plus/DeviceConfig.h
+++ b/CO2-Ampel_Plus/DeviceConfig.h
@@ -12,6 +12,10 @@ typedef struct  {
   char mqtt_topic[20];
   char ampel_name[40];
   float temperature_offset;
+  char mqtt_username[20];
+  char mqtt_password[20];
+  bool light_enabled;
+  bool buzzer_enabled;  
 } device_config_t;
 
 void config_set_factory_defaults();

--- a/CO2-Ampel_Plus/NetworkManager.cpp
+++ b/CO2-Ampel_Plus/NetworkManager.cpp
@@ -227,7 +227,15 @@ void wifi_handle_client(){
                   requestParser.getField("ampel").toCharArray(cfg.ampel_name, 40);
                 }
                 
-                /**
+                if((requestParser.getField("buzzer").length() > 0)){
+                  if (requestParser.getField("buzzer") == "false") {
+                    cfg.buzzer_enabled = false;
+                  } else {
+                    cfg.buzzer_enabled = true;
+                  }
+                }
+
+               /**
                  * Reboot if required.
                  */
                 if (reboot){
@@ -374,6 +382,17 @@ void wifi_handle_client(){
             client.print("<input type=password name=ap_pwd placeholder='Passwort' value='");
             client.print(cfg.ap_password);
             client.print("'>");
+            
+            client.print("<label for=buzzer>Buzzer</label>");
+            client.print("<select id=buzzer name=buzzer size=2>");
+            if (cfg.buzzer_enabled) {
+                client.print("<option value=\"true\" selected>Enabled</option>");
+                client.print("<option value=\"false\">Disabled</option>");
+            } else {
+                client.print("<option value=\"true\">Enabled</option>");
+                client.print("<option value=\"false\" selected>Disabled</option>");              
+            };
+            client.print("</select>");
             
             //client.print("<div class=\"btnbox\"><button onclick=\"window.location.href='/selftest'\"  class=\"btn\">Selftest</button></div>");
             //client.print("<div class=\"btnbox\"><button onclick=\"window.location.href='/calibrate'\" class=\"btn\">Calibration</button></div>");

--- a/CO2-Ampel_Plus/NetworkManager.cpp
+++ b/CO2-Ampel_Plus/NetworkManager.cpp
@@ -211,6 +211,18 @@ void wifi_handle_client(){
                   cfg.mqtt_broker_port = requestParser.getField("port").toInt();
                 }
 
+                if((requestParser.getField("topic").length() > 0)){
+                  requestParser.getField("topic").toCharArray(cfg.mqtt_topic, 20);
+                }
+
+                if((requestParser.getField("mqttuser").length() > 0)){
+                  requestParser.getField("mqttuser").toCharArray(cfg.mqtt_username, 20);
+                }
+
+                if((requestParser.getField("mqttpass").length() > 0)){
+                  requestParser.getField("mqttpass").toCharArray(cfg.mqtt_password, 20);
+                }
+
                 if((requestParser.getField("ampel").length() > 0)){
                   requestParser.getField("ampel").toCharArray(cfg.ampel_name, 40);
                 }
@@ -326,6 +338,21 @@ void wifi_handle_client(){
             client.print("<label for=port>MQTT Broker Port</label>");
             client.print("<input name=port placeholder='1883' value='");
             client.print(cfg.mqtt_broker_port); 
+            client.print("'>");
+        
+            client.print("<label for=port>MQTT Base Topic</label>");
+            client.print("<input name=topic placeholder='sensors' value='");
+            client.print(cfg.mqtt_topic); 
+            client.print("'>");
+        
+            client.print("<label for=port>MQTT Username</label>");
+            client.print("<input name=mqttuser placeholder='username' value='");
+            client.print(cfg.mqtt_username); 
+            client.print("'>");
+        
+            client.print("<label for=port>MQTT Password</label>");
+            client.print("<input type=password name=mqttpass placeholder='password' value='");
+            client.print(cfg.mqtt_password); 
             client.print("'>");
         
             client.print("<label for=ampel>Ampel Name</label>");


### PR DESCRIPTION
I added support for MQTT Username and Password, configuration posibilities for it and MQTT Base Topic and a method to enable/disable the Buzzer from the configuration page for silent operation.  

This pull request implements https://github.com/mariolukas/Watterott-CO2-Ampel-Plus-Firmware/issues/2 