### PR TITLE
No Startup unless Serial Monitor connected fixed

### DIFF
--- a/CO2-Ampel_Plus/CO2-Ampel_Plus.ino
+++ b/CO2-Ampel_Plus/CO2-Ampel_Plus.ino
@@ -39,9 +39,11 @@ Button modeButton(BUTTON_PIN);
 int wifi_reconnect_attemps = WIFI_RECONNECT_ATTEMPTS;
 
 void setup() {
+#if DEBUG_LOG > 0  
   while (!Serial) {
      ; // wait for serial port to connect.
   }
+#endif
   Serial.begin(115200);
   Serial.println("------------------------");
   Serial.println("Starting setup...");


### PR DESCRIPTION
Added #if DEBUG_LOG > 0 to avoid waiting for serial connection if not in DEBUG mode.

Fixes issue #9 