### PR TITLE
MQTT Reconnect

### DIFF
--- a/CO2-Ampel_Plus/NetworkManager.cpp
+++ b/CO2-Ampel_Plus/NetworkManager.cpp
@@ -96,9 +96,7 @@ int wifi_wpa_connect() {
   } else {
     print_wifi_status();
     server.begin();
-    if (strcmp(cfg.mqtt_broker_address, "127.0.0.1")) { /* prevent connection to localhost */
-      mqtt_connect();
-    }
+    mqtt_connect();
   }
 
   return wifi_status;


### PR DESCRIPTION
If the connection to the MQTT broker drops, e.g. because the broker is offline for a while, the firmware did never try to reconnect. This PR implements a reconnect functionality. If the function mqtt_send_value() detects no connection, mqtt_connect() will be called and the next mqtt_send_value() will be able to post successfully again.