### PR TITLE
- added support for light_enabled config option to led_set_brightness()

### DIFF
--- a/CO2-Ampel_Plus/LED.cpp
+++ b/CO2-Ampel_Plus/LED.cpp
@@ -2,6 +2,7 @@
 #include "Led.h"
 #include "Buzzer.h"
 #include "Config.h"
+#include "DeviceConfig.h"
 
 Adafruit_NeoPixel ws2812 = Adafruit_NeoPixel(NUMBER_OF_WS2312_PIXELS,
                                              PIN_WS2812,
@@ -87,7 +88,12 @@ void led_set_color(uint32_t color) {
 }
 
 void led_set_brightness() {
-  ws2812.setBrightness(led_brightness);
+  device_config_t cfg = config_get_values();
+  if (cfg.light_enabled) {
+    ws2812.setBrightness(led_brightness);
+  } else {
+    ws2812.setBrightness(0);
+  }
 }
 
 void led_adjust_brightness(byte brightness) {

--- a/CO2-Ampel_Plus/MQTTManager.cpp
+++ b/CO2-Ampel_Plus/MQTTManager.cpp
@@ -2,6 +2,7 @@
 #include "Config.h"
 #include "DeviceConfig.h"
 #include "Led.h"
+#include <ArduinoJson.h>
 
 WiFiClient wifi_client;
 PubSubClient mqttClient(wifi_client);
@@ -13,6 +14,7 @@ int willQoS = 1;
 bool mqtt_connect() {
   device_config_t cfg = config_get_values();
   char willTopic[200];
+  char setTopic[200];
   if (strcmp(cfg.mqtt_broker_address, "127.0.0.1")) { /* prevent connection to localhost */
     sprintf(willTopic, "%s/%s/%s", cfg.mqtt_topic, cfg.ampel_name,
             MQTT_LWT_SUBTOPIC);
@@ -22,6 +24,7 @@ bool mqtt_connect() {
     Serial.print(":");
     Serial.println(cfg.mqtt_broker_port);
     mqttClient.setServer(cfg.mqtt_broker_address, cfg.mqtt_broker_port);
+    mqttClient.setCallback(mqtt_message_received);
     if (!mqttClient.connect(cfg.ampel_name, cfg.mqtt_username, cfg.mqtt_password,
                             willTopic, willQoS, willRetain, willMessage)) {
       Serial.println("Could not connect to server.");
@@ -37,6 +40,12 @@ bool mqtt_connect() {
       return false;
     }
     mqttClient.publish(willTopic, "connected");
+    sprintf(setTopic, "%s/%s/%s", cfg.mqtt_topic, cfg.ampel_name,
+            MQTT_SET_SUBTOPIC);
+    if (mqttClient.subscribe(setTopic)) {
+      Serial.print("Subscribed to topic ");
+      Serial.println(setTopic);
+    }
     return true;
   }
 }
@@ -70,5 +79,52 @@ void mqtt_send_value(int co2, int temp, int hum, int lux) {
   } else {
     Serial.println("Data publication failed, client is not connected. Trying to reconnect.");
     mqtt_connect();
+  }
+  mqttClient.loop();
+}
+
+void mqtt_message_received(char* topic, byte* payload, unsigned int length) {
+  device_config_t cfg = config_get_values();
+  String topicToProcess = topic;
+  payload[length] = '\0';
+  String payloadToProcess = (char*)payload;
+#if DEBUG_LOG > 0
+  Serial.print("Message arrived [");
+  Serial.print(topicToProcess);
+  Serial.print("]: ");
+  Serial.println(topicToProcess);
+#endif
+  // Parse message into JSON
+  DynamicJsonDocument doc(1024);
+  auto error = deserializeJson(doc, payload);
+  // Check if payloadToProcess is valid JSON
+  if (error) {
+    Serial.print(F("deserializeJson() failed with code "));
+    Serial.println(error.c_str());
+    return;
+  }
+  // Retrieve the values
+  if (doc.containsKey("light_enabled")) {
+    String light_enabled = doc["light_enabled"];
+    if (light_enabled.equalsIgnoreCase(F("true"))) {
+      Serial.println("Light enabled via MQTT");
+      cfg.light_enabled = true;
+    } else if (light_enabled.equalsIgnoreCase(F("false"))) {
+      Serial.println("Light disabled via MQTT");
+      cfg.light_enabled = false;
+    }
+    config_set_values(cfg);
+    led_set_brightness();
+  }
+  if (doc.containsKey("buzzer_enabled")) {
+    String buzzer_enabled = doc["buzzer_enabled"];
+    if (buzzer_enabled.equalsIgnoreCase(F("true"))) {
+      Serial.println("Buzzer enabled via MQTT");
+      cfg.buzzer_enabled = true;
+    } else if (buzzer_enabled.equalsIgnoreCase(F("false"))) {
+      Serial.println("Buzzer disabled via MQTT");
+      cfg.buzzer_enabled = false;
+    }
+    config_set_values(cfg);
   }
 }

--- a/CO2-Ampel_Plus/MQTTManager.h
+++ b/CO2-Ampel_Plus/MQTTManager.h
@@ -4,9 +4,11 @@
 #include <WiFi101.h>
 #include "Led.h"
 #include "NetworkManager.h"
+#include <ArduinoJson.h>
 
 bool mqtt_connect();
 void mqtt_send_value(int co2, int temp, int hum, int lux);
 bool mqtt_broker_connected();
+void mqtt_message_received(char* topic, byte* payload, unsigned int length);
 
 #endif


### PR DESCRIPTION
- added support for configuration of light_enabled and buzzer_enabled via MQTT
  A new, configurable sub-topic is introduced. The sensor subscribes tothis topic on startup and accepts JSON formated MQTT payloads to configure light_enabled and/or buzzer_enabled.