### PR TITLE
Reconnect to Wifi when connection drops

### DIFF
--- a/CO2-Ampel_Plus/CO2-Ampel_Plus.ino
+++ b/CO2-Ampel_Plus/CO2-Ampel_Plus.ino
@@ -126,6 +126,10 @@ void loop() {
       break;
   }
 
+  if (!wifi_is_connected()) {
+    wifi_state = WIFI_MODE_WPA_CONNECT;
+  }
+
   wifi_handle_client();
   sensor_handler();
   sensor_handle_brightness();


### PR DESCRIPTION
This PR addresses the issue of the Ampel losing Wifi connectivity until it is rebooted.
The fix ensures that when Wifi connectivity is lost, a re-connection is attempted to ensure the continued delivery of MQTT telemetry.