### PR TITLE
Fix field name search function (#31)

### DIFF
--- a/CO2-Ampel_Plus/RequestParser.cpp
+++ b/CO2-Ampel_Plus/RequestParser.cpp
@@ -124,14 +124,26 @@ String RequestParser::getPayload() {
 }
 
 String RequestParser::getField(String key) {
-  int keyIndex = _payload.indexOf(key);
+  // Make sure, the first field name in the _payload starts with &
+  String searchPayload = "&";
+  searchPayload += _payload;
+
+  // Search the field name by &key (like &ampel)
+  // This prevents that a field value is unfortunately used as a field name.
+  String searchKey = "&";
+  searchKey += key;
+
+  int keyIndex = searchPayload.indexOf(searchKey);
 
   if (keyIndex == -1) {
     return "";
   }
 
-  int startIndex = _payload.indexOf("=", keyIndex);
-  int stopIndex = _payload.indexOf("&", keyIndex);
+  // Jump over the field name prefix "&"
+  keyIndex += 1;
 
-  return urldecode(_payload.substring(startIndex + 1, stopIndex));
+  int startIndex = searchPayload.indexOf("=", keyIndex);
+  int stopIndex = searchPayload.indexOf("&", keyIndex);
+
+  return urldecode(searchPayload.substring(startIndex + 1, stopIndex));
 }


### PR DESCRIPTION
In some circumstances, it may happen, that a (part of a ) field value is recognized
as a field name which leads to wrong configuration.